### PR TITLE
OpenShift 201 Autoscaling Pods grammar and clarity fixes

### DIFF
--- a/openshift-201/resource-mgmt.md
+++ b/openshift-201/resource-mgmt.md
@@ -136,7 +136,7 @@ spec:
 ```
 **Note:** As we don't set limits and request specifically in the deployment the default LimitRange will apply. Run `oc describe LimitRange/default-limits` to see what is set as defaults.
 
-From the web console, change to Developer view and navigate to the Observe tab. From the Workload dashboard, select your nginx deployment. You should see the load-test pod traffic increasing CPU and Memory usage metrics for the nginx workload.
+From the web console, change to Developer view and navigate to the Observe tab. From the Workload dashboard, select your nginx deployment. You should see the load-test pod traffic increasing CPU and memory usage metrics for the nginx workload.
 
 ![cpu load](images/resource-mgmt/pod-load-cpu.png) 
 

--- a/openshift-201/rh201-pod-auto-scale.md
+++ b/openshift-201/rh201-pod-auto-scale.md
@@ -23,7 +23,7 @@ You will need to determine what metric is best for your application to trigger s
 
 Run load-test to generate some traffic to nginx server `oc scale deployment load-test --replicas=1`. You should see the number of pods increase as the CPU metrics grow.
 
-To get information about horizontal pod autoscaler resources in the current project, use the oc get command.
+To get information about horizontal pod autoscaler resources in the current project, use the `oc get hpa` command.
 
 ```yaml
 oc get hpa 
@@ -33,7 +33,7 @@ hello-world-nginx   Deployment/hello-world-nginx   600%/80%   1         5       
 
 The TARGETS column is the metrics on pods as a percentage of cpu request at current/target.
 
-The horizontal pod autoscaler initially has a value of `<unknown>` in the TARGETS column. It might take up to five minutes before <unknown> changes to display a percentage for current usage.
+The horizontal pod autoscaler initially has a value of `<unknown>` in the TARGETS column. It might take up to five minutes before `<unknown>` changes to display a percentage for current usage.
 
 A persistent value of `<unknown>` in the TARGETS column might indicate that the deployment does not define resource requests for the metric. The horizontal pod autoscaler will not scale these pods.
 

--- a/openshift-201/rh201-pod-auto-scale.md
+++ b/openshift-201/rh201-pod-auto-scale.md
@@ -110,7 +110,7 @@ Specify averageUtilization and a target average memory utilization over all the 
 
 For memory-based autoscaling, memory usage must increase and decrease proportionally to the replica count. On average an increase in replica count must lead to an overall decrease in memory (working set) usage per-pod. A decrease in replica count must lead to an overall increase in per-pod memory usage.
 
-Apply the `hello-world-nginx-mem-hpa` from above to your project. Trigger a re-deploy of the load-test deployment.
+Replace your existing HPA with the `hello-world-nginx-mem-hpa` spec from above in your project. Trigger a re-deploy of the load-test deployment.
 
 Describe the HPA.
 

--- a/openshift-201/rh201-pod-auto-scale.md
+++ b/openshift-201/rh201-pod-auto-scale.md
@@ -31,7 +31,7 @@ NAME                REFERENCE                      TARGETS    MINPODS   MAXPODS 
 hello-world-nginx   Deployment/hello-world-nginx   600%/80%   1         5          4        
 ```
 
-The TARGETS column is the metrics on pods as a percentage of cpu request at current/target.
+The TARGETS column is the metrics on pods as a percentage of CPU request at current/target.
 
 The horizontal pod autoscaler initially has a value of `<unknown>` in the TARGETS column. It might take up to five minutes before `<unknown>` changes to display a percentage for current usage.
 

--- a/openshift-201/rh201-pod-auto-scale.md
+++ b/openshift-201/rh201-pod-auto-scale.md
@@ -177,14 +177,14 @@ The VPA custom resources (CR) must be in the same project as the pods you want t
 * Off, only provides recommended resource limits and requests, allowing you to manually apply the recommendations. The off mode does not update pods.
 
 
-Lets first confirm that the VPA operator is installed in our cluster, we should see 2 results.
+Let's first confirm that the VPA operator is installed in our cluster, we should see 2 results.
 
 ```
 oc api-resources | grep vpa
 ```
 ### Update Mode Off
 
-Lets now create a VPA with update mode turned to "Off" so we just get resource recommendations.
+Let's now create a VPA with update mode turned to "Off" so we just get resource recommendations.
 
 Create a VPA using the below yaml:
 
@@ -244,13 +244,13 @@ If the VPA updateMode uses something other than `off` then the lowerBound and up
 
 ### Update Mode Auto
 
-Lets create an VPA in auto mode and send traffic to the hello-world-nginx pods and observe what happens.
+Let's create an VPA in auto mode and send traffic to the hello-world-nginx pods and observe what happens.
 
-> Note: VPAs in Auto updateMode won't work with HPA using the same CPU and memory metrics because it would cause a race condition. If HPA objects still exists from previous labs lets delete them to focus on VPAs.
+> Note: VPAs in Auto updateMode won't work with HPA using the same CPU and memory metrics because it would cause a race condition. If HPA objects still exists from previous labs, let's delete them to focus on VPAs.
 
-Then lets scale our hello-world-nginx deployment replicas up to three so the VPA can re-deploy our pods if needed.
+Then let's scale our hello-world-nginx deployment replicas up to three so the VPA can re-deploy our pods if needed.
 
-Then lets create another VPA in Auto updateMode:
+Then let's create another VPA in Auto updateMode:
 
 ```yaml
 cat <<EOF | oc apply -f -
@@ -306,7 +306,7 @@ When you specify the value as a percentage it may not map to an exact number of 
 A maxUnavailable of 0% or 0 or a minAvailable of 100% or equal to the number of replicas is permitted but can block nodes from being drained. It will also generate alerts for the Operations team who will contact you asking for it to be adjusted. **THIS IS IMPORTANT**, your configuration of a PDB in your project could effect a cluster wide upgrade process. If your using PDBs then be a good neighbor and ensure that it's configured correctly and that you are keeping an eye on it or configured monitoring to ensure the PDB is still valid for the deployment or object it's pointing to.
 
 
-Lets create a pod disruption budget where we always want at least 1 Nginx pod to be available for our deployment. Apply the following config to your project.
+Let's create a pod disruption budget where we always want at least 1 Nginx pod to be available for our deployment. Apply the following config to your project.
 
 ```yaml
 apiVersion: policy/v1beta1
@@ -341,7 +341,7 @@ There are two types of pod anti-affinity rules: required and preferred. (You can
 
 You configure pod anti-affinity through the Pod spec files. You can specify a required rule, a preferred rule, or both. If you specify both, the node must first meet the required rule, then attempts to meet the preferred rule.
 
-Lets update our deployment to add an anti-affinity rule.
+Let's update our deployment to add an anti-affinity rule.
 
 > Note: If there are still HPAs or VPAs in place in your project you should clean them out.
 


### PR DESCRIPTION
@mtspn I've edited the Autoscaling Pods document within the OpenShift 201 content to:

- Clarify in the HPA section that a new YAML spec should replace an old one, as opposed to having multiple HPAs at once (e0e025ef9b232d196deec30aa780b7d3f21dd558)
- Add backticks around all inline commands so they all appear as mono-spaced `<code>` blocks (f4d3694340c5d045aaccf068706120e374be277d)
- Fix capitalization on "CPU" and "memory" in body text (c351a5b481f1fd8767cc6d9fc3512267f226ca3e)
- Fix apostrophes on "lets" vs "let's" (ecf47867181895983970ee0fc26cc2020e397dc5)