### PR TITLE
Update deployment strategy section for clarity

### DIFF
--- a/101-lab/content/04_configuring_deployments.md
+++ b/101-lab/content/04_configuring_deployments.md
@@ -23,15 +23,16 @@ Review the deployment configuration `ReplicaSets` tab:
   - Compare the differences between that replica set and an older one - this can be done through the UI or by comparing the YAML
 
 ## Changing the Deployment Strategy Option
-The default deployment configuration provides a `RollingUpdate` style deployment, which waits for the container to be ready prior to cutting over traffic and terminating the previous container.
+The default deployment configuration provides a `RollingUpdate` deployment strategy, which waits for the container to be ready prior to cutting over traffic and terminating the previous container. Explore what happens when you change your deployment strategy.
   - Navigate back to your rocketchat-[username] deployment.
-  - From the Actions menu, select "Edit update strategy". Change the strategy to a `Recreate`. Next, redeploy a couple of times by editing your pod count to zero, then increasing to one pod (Actions menu -> Edit Pod count, or update `spec.replicas` in the YAML).
-  - Edit the YAML for the deployment and change the `spec.strategy.type` from `RollingUpdate` to `Recreate`. Make sure to remove the `spec.strategy.rollingUpdate` node as in the screenshots below.
-![Rocketchat deployment details screen showing YAML tab with RollingUpdate strategy](./images/04_deploy_strategy_01.png)
-![Rocketchat deployment details screen showing YAML tab with Recreate strategy](./images/04_deploy_strategy_02.png)
+  - Edit your deployment strategy using one of the methods below:
+    - From the Actions menu, select "Edit update strategy". Change the strategy to a `Recreate`. Or,
+    - Edit the YAML for the deployment and change the `.spec.strategy.type` from `RollingUpdate` to `Recreate`. Make sure to remove the `.spec.strategy.rollingUpdate` node as in the screenshots below.
+    ![Rocketchat deployment details screen showing YAML tab with RollingUpdate strategy](./images/04_deploy_strategy_01.png)
+    ![Rocketchat deployment details screen showing YAML tab with Recreate strategy](./images/04_deploy_strategy_02.png)
   - Now make a small change to the deployment to trigger a new deploy (for testing):
     - `oc -n [-dev] set env deployment/rocketchat-[username] TEST=BAR`
   - Go back to Topology and observe the behaviour. You should notice that the old pod is killed before a new one is created.
-  - Edit the YAML and switch the strategy back to `RollingUpdate`.
+  - Change your deployment strategy back to `RollingUpdate` by using the Actions menu or by editing the YAML directly.
 
 Next page - [Resource Management](./05_resource_management.md)


### PR DESCRIPTION
This PR is updating the Deployment Strategy section of the Configuring Deployments page to make the instructions more clear. There are two different methods for describing how the deployment strategy can be changed, and this update makes it more clear that there is a choice (through the GUI with the Actions menu., or editing YAML).

Tagging @mtspn for review.