### PR TITLE
Hpa changes

### DIFF
--- a/openshift-201/rh201-pod-auto-scale.md
+++ b/openshift-201/rh201-pod-auto-scale.md
@@ -44,7 +44,7 @@ A persistent value of `<unknown>` in the TARGETS column might indicate that the 
 
 ### API Versions 
 
-There are different API versions for autoscaling. `autoscaling/v2` is the new default horizontal pod autoscaler version since `oc 4.12`
+There are different API versions for autoscaling. `autoscaling/v2` is the new default horizontal pod autoscaler version since `oc 4.12`.
 
 |Metric | Description | API version|
 |---|---|----|

--- a/openshift-201/rh201-pod-auto-scale.md
+++ b/openshift-201/rh201-pod-auto-scale.md
@@ -44,7 +44,7 @@ A persistent value of `<unknown>` in the TARGETS column might indicate that the 
 
 ### API Versions 
 
-There are different API versions for autoscaling. v1 API just works with CPU metrics, v2beta2 API handles more options and metrics including CPU and memory.
+There are different API versions for autoscaling. `autoscaling/v2` is the new default horizontal pod autoscaler version since `oc 4.12`
 
 |Metric | Description | API version|
 |---|---|----|
@@ -57,10 +57,10 @@ You can check the autoscaling API versions available in the cluster.
 oc  api-versions | grep autoscaling
 ```
 
-The `oc autoscale` command will create a v1 type autoscaler. You can view with the HPA details with an `oc -n [-dev] get hpa hello-world-nginx -o yaml` command.
+The `oc autoscale` command will create a v2 type autoscaler. You can view with the HPA details with an `oc -n [-dev] get hpa hello-world-nginx -o yaml` command.
 
 ```yaml
-apiVersion: autoscaling/v1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: hello-world-nginx
@@ -97,7 +97,7 @@ spec:
         averageValue: 30Mi
 ```
 
-Under metrics.resource.target you can set type to AverageValue and specify averageValue memory. You can also specify Utilization in the metrics section of the v2beta2 HPA. Check out the available options by `oc explain --api-version='autoscaling/v2beta2' HorizontalPodAutoscaler.spec.metrics.resource.target`. Note you'll need to specify the API version as it defaults to v1.
+Under metrics.resource.target you can set type to AverageValue and specify averageValue memory. You can also specify Utilization in the metrics section of the v2beta2 HPA. Check out the available options by `oc explain --api-version='autoscaling/v2beta2' HorizontalPodAutoscaler.spec.metrics.resource.target`. Note you'll need to specify the API version as it defaults to v2.
 
 ```yaml
 metrics: 


### PR DESCRIPTION
PR relating to changes to reflect the new default HPA version in the 201 lab. As suggested by Willem, captured [in this ticket](https://app.zenhub.com/workspaces/platform-experience-5bb7c5ab4b5806bc2beb9d15/issues/gh/bcdevops/developer-experience/3959). 

I've also made minor changes to the [201 mural board](https://app.mural.co/invitation/mural/platformservices5977/1648237994578?sender=uf0df5317d8dbea9ee48c7230&key=b330343a-acb1-47e5-85d9-0fadde8f53c5) to reference the v2 hpa. 