### PR TITLE
Use Zone for anti-affinity

### DIFF
--- a/openshift-201/rh201-pod-auto-scale.md
+++ b/openshift-201/rh201-pod-auto-scale.md
@@ -479,7 +479,7 @@ Let's update our deployment to add an anti-affinity rule.
                   operator: In 
                   values:
                   - hello-world-nginx
-            topologyKey: kubernetes.io/hostname
+            topologyKey: topology.kubernetes.io/zone
       containers:
 .
 .


### PR DESCRIPTION
Now that all the nodes have a zone label, we can use it instead for pod anti-affinity instead of just the node name.

We may also want to look into https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/