### PR TITLE
Update link to lab 201 slides

### DIFF
--- a/openshift-201/README.md
+++ b/openshift-201/README.md
@@ -1,7 +1,7 @@
 # OpenShift 201 Training Labs
 Welcome to the OpenShift 201 Training Labs. 
 The lab materials in this folder are designed to accompany the OpenShift 201 Workshop.
-You may want to reference the [OpenShift 201 Workshop Slides](https://app.mural.co/t/platformservices5977/m/platformservices5977/1648237994578/6d72899801ba0c9b04e4f120571621c188c92036?sender=u66de390c4d3da408f9803733) as you work through the lab.
+You may want to reference the [OpenShift 201 Workshop Slides](https://docs.google.com/presentation/d/1h1123AfJx5k9shYZc6JpHdpKbJSt_qcdDf9V_We9qNc) as you work through the lab.
 
 
 ### Prerequisites:

--- a/openshift-201/README.md
+++ b/openshift-201/README.md
@@ -1,5 +1,7 @@
 # OpenShift 201 Training Labs
-Welcome to the OpenShift 201 Training Labs.  You will find all of the lab materials in this folder which accompany the 201 presentations found [here](https://app.mural.co/t/platformservices5977/m/platformservices5977/1648237994578/6d72899801ba0c9b04e4f120571621c188c92036?sender=u66de390c4d3da408f9803733).
+Welcome to the OpenShift 201 Training Labs. 
+The lab materials in this folder are designed to accompany the OpenShift 201 Workshop.
+You may want to reference the [OpenShift 201 Workshop Slides](https://app.mural.co/t/platformservices5977/m/platformservices5977/1648237994578/6d72899801ba0c9b04e4f120571621c188c92036?sender=u66de390c4d3da408f9803733) as you work through the lab.
 
 
 ### Prerequisites:


### PR DESCRIPTION
The [OpenShift 201 Lab README](https://github.com/BCDevOps/devops-platform-workshops/blob/master/101-lab/content/README.md) references [OpenShift 201 mural slides](https://app.mural.co/t/platformservices5977/m/platformservices5977/1648237994578/6d72899801ba0c9b04e4f120571621c188c92036?sender=u66de390c4d3da408f9803733). The correct slides are [OpenShift 201 Workshop Google Slides](https://docs.google.com/presentation/d/1h1123AfJx5k9shYZc6JpHdpKbJSt_qcdDf9V_We9qNc).

This PR corrects this link and fixes #202.