### PR TITLE
Correct link to next page in 00_overview.md

### DIFF
--- a/101-lab/content/00_overview.md
+++ b/101-lab/content/00_overview.md
@@ -28,4 +28,4 @@ While we love the idea of everyone getting their hands onto Openshift. The indiv
 
 __Please be aware the throughout the labs, you will be guided to make common mistakes, and then guide you on how to fix them.__
 
-Next page - [Setup](./01_adding_team_members.md)
+Next page - [Setup](./01_setup.md)


### PR DESCRIPTION
In the [Overview](https://github.com/BCDevOps/devops-platform-workshops/blob/master/101-lab/content/00_overview.md) page, the Next Page link to setup actually links to adding team members. This PR corrects that link.