### PR TITLE
Fix broken hostnames in rocketchat MONGO_URL/ROOT_URL example

### DIFF
--- a/101-lab/content/03_deployment.md
+++ b/101-lab/content/03_deployment.md
@@ -327,7 +327,7 @@ This is shown in the image below (**note that you need to replace [username] wit
 
 Alternatively, you can use the CLI to apply the environment variables:
 ```
-oc -n [-dev] set env deployment/rocketchat-[username] "MONGO_URL=mongodb://rocketchat:rocketchatpass@mongodb-27017/rocketchat" "ROOT_URL=http://rocketchat-3000"
+oc -n [-dev] set env deployment/rocketchat-[username] "MONGO_URL=mongodb://rocketchat:rocketchatpass@mongodb-[username]:27017/rocketchat" "ROOT_URL=http://rocketchat-[username]:3000"
 ```
 
 Expected output from the above command:


### PR DESCRIPTION
The `oc set env` example in the docs concatenated the service name and port without a separator, producing invalid hostnames: 

`mongodb-27017` (should be `mongodb-[username]:27017`) and `rocketchat-3000` (should be `rocketchat-[username]:3000`).

Both the username placeholder and the colon before the port number were missing. Following the doc as written sets MONGO_URL and ROOT_URL to unreachable hosts. The command succeeds with no error at apply time, but Rocket.Chat fails to connect to MongoDB and gets the wrong root URL, which isn't obvious until you check pod logs or try to load the app.

This PR restores the username placeholder and colon so the generated values match the actual service names (`mongodb-[username]`, `rocketchat-[username]`) created earlier in the lab.